### PR TITLE
Fix status code & response for phone-numbers that already have an existing account

### DIFF
--- a/server/controllers/users.js
+++ b/server/controllers/users.js
@@ -83,8 +83,9 @@ exports.createNewUser = function (req, res, accountVerificationStatus) {
           });
       
         } else if (scanResults.length > 0) {
-          logger.info('Phone number already registered, cannot create user');
-          res.send(401);
+          const errorMessage = 'Phone number already registered, cannot create user';
+          logger.info(errorMessage);
+          return res.status(401).json({message: errorMessage});
         }
       }
     });


### PR DESCRIPTION
Since we have no way to allow users to sign-in we can't just reject the "signup" request for existing phone numbers.  We have to just create the account & hope the number hasn't changed hands.

We can remove this behavior as soon as there is a way for the user to sign-in.